### PR TITLE
Fix set and clear cookies for all domains

### DIFF
--- a/src/components/cookies.ts
+++ b/src/components/cookies.ts
@@ -74,16 +74,9 @@ export const getAuthCookies = (req: Request) => {
     };
 };
 
-export const clearAuthCookies = (req: Request, res: Response) => {
-    const baseCookieOptions = getBaseCookieOptions(req);
-
-    res.clearCookie(AUTH_COOKIE_NAME, {
-        ...baseCookieOptions,
-        httpOnly: true,
-    })
-        .clearCookie(AUTH_EXP_COOKIE_NAME, {...baseCookieOptions, httpOnly: false})
-        .clearCookie(AUTH_COOKIE_NAME) // without params for correct clear if any params was changed
-        .clearCookie(AUTH_EXP_COOKIE_NAME); // without params for correct clear if any params was changed
+export const clearAuthCookies = (_: Request, res: Response) => {
+    // without params for correct clear if any params was changed
+    res.clearCookie(AUTH_COOKIE_NAME).clearCookie(AUTH_EXP_COOKIE_NAME);
 };
 
 export function getBaseCookieOptions(req: Request) {

--- a/src/components/cookies.ts
+++ b/src/components/cookies.ts
@@ -74,9 +74,16 @@ export const getAuthCookies = (req: Request) => {
     };
 };
 
-export const clearAuthCookies = (_: Request, res: Response) => {
-    // without params for correct clear if any params was changed
-    res.clearCookie(AUTH_COOKIE_NAME).clearCookie(AUTH_EXP_COOKIE_NAME);
+export const clearAuthCookies = (req: Request, res: Response) => {
+    const baseCookieOptions = getBaseCookieOptions(req);
+
+    res.clearCookie(AUTH_COOKIE_NAME, {
+        ...baseCookieOptions,
+        httpOnly: true,
+    })
+        .clearCookie(AUTH_EXP_COOKIE_NAME, {...baseCookieOptions, httpOnly: false})
+        .clearCookie(AUTH_COOKIE_NAME) // without params for correct clear if any params was changed
+        .clearCookie(AUTH_EXP_COOKIE_NAME); // without params for correct clear if any params was changed
 };
 
 export function getBaseCookieOptions(req: Request) {

--- a/src/tests/int/env/opensource/suites/auth.test.ts
+++ b/src/tests/int/env/opensource/suites/auth.test.ts
@@ -176,7 +176,7 @@ describe('Auth', () => {
         const authCookies = settedCookies.filter((cookie) =>
             [AUTH_COOKIE_NAME, AUTH_EXP_COOKIE_NAME].includes(cookie.name),
         );
-        expect(authCookies.length).toBe(4); // 2 with params, 2 without params
+        expect(authCookies.length).toBe(2);
 
         authCookies.forEach((cookie) => {
             expect(cookie.value).toStrictEqual('');

--- a/src/tests/int/env/opensource/suites/auth.test.ts
+++ b/src/tests/int/env/opensource/suites/auth.test.ts
@@ -176,7 +176,7 @@ describe('Auth', () => {
         const authCookies = settedCookies.filter((cookie) =>
             [AUTH_COOKIE_NAME, AUTH_EXP_COOKIE_NAME].includes(cookie.name),
         );
-        expect(authCookies.length).toBe(2);
+        expect(authCookies.length).toBe(4); // 2 with params, 2 without params
 
         authCookies.forEach((cookie) => {
             expect(cookie.value).toStrictEqual('');


### PR DESCRIPTION
https://expressjs.com/en/api.html#res.clearCookie

Simple removal of explicit cookie parameters does not guarantee that all possible copies of a cookie will be deleted if those cookies were originally set with different parameters (such as `path`, `domain`, `secure`, or `sameSite`). This is highly dependent on browser behavior, so calling `clearCookie` multiple times with different option combinations is a common and recommended practice to ensure all potential copies are properly cleared.